### PR TITLE
QueryCompiler & QueryStatementCompiler

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -26,6 +26,10 @@
 	path = third_party/orc
 	url = https://github.com/apache/orc.git
 	shallow = true
+[submodule "third_party/sql-parser"]
+	path = third_party/sql-parser
+	url = https://github.com/hyrise/sql-parser.git
+	shallow = true
 [submodule "third_party/termcolor"]
 	path = third_party/termcolor
 	url = https://github.com/ikalnytskyi/termcolor

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,6 +16,7 @@ include_directories(
     ${PROJECT_SOURCE_DIR}/third_party/cxxopts/include
     ${PROJECT_SOURCE_DIR}/third_party/magic_enum/include
     ${PROJECT_SOURCE_DIR}/third_party/orc/c++/include
+    ${PROJECT_SOURCE_DIR}/third_party/sql-parser/src
     ${PROJECT_SOURCE_DIR}/third_party/termcolor/include
     ${PROJECT_SOURCE_DIR}/third_party/tpch-dbgen
     ${CMAKE_BINARY_DIR}/third_party/orc/c++/include

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -323,6 +323,8 @@ set(
     arrow_dataset_static
     parquet_static
     arrow_static
+        
+    sqlparser
 )
 
 add_library(skyriseSharedLibrary STATIC ${SHARED_SOURCES})

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -10,6 +10,10 @@ set(
     compiler/compilation_context.hpp
     compiler/logical_query_plan/functional_dependency.cpp
     compiler/logical_query_plan/functional_dependency.hpp
+    compiler/query_compiler.cpp
+    compiler/query_compiler.hpp
+    compiler/query_statement_compiler.cpp
+    compiler/query_statement_compiler.hpp
 )
 
 set(

--- a/src/lib/compiler/query_compiler.cpp
+++ b/src/lib/compiler/query_compiler.cpp
@@ -1,0 +1,134 @@
+#include "query_compiler.hpp"
+
+#include <boost/algorithm/string.hpp>
+
+#include "query_context.hpp"
+#include "sql/create_sql_parser_error_message.hpp"
+#include "utils/assert.hpp"
+
+namespace skyrise {
+
+QueryCompiler::QueryCompiler(std::string sql_query, std::shared_ptr<AbstractCatalog> catalog,
+                             std::string target_bucket_name)
+    : sql_query_(std::move(sql_query)),
+      catalog_(std::move(catalog)),
+      target_bucket_name_(std::move(target_bucket_name)) {
+  // (1) Get parse result from SQLParser & calculate runtime
+  hsql::SQLParserResult parse_result;
+  {
+    const auto start = std::chrono::high_resolution_clock::now();
+    hsql::SQLParser::parse(sql_query_, &parse_result);
+    const auto done = std::chrono::high_resolution_clock::now();
+    metrics_.parse_time_nanos = std::chrono::duration_cast<std::chrono::nanoseconds>(done - start);
+  }
+
+  AssertInput(parse_result.isValid(), CreateSqlParserErrorMessage(sql_query_, parse_result));
+  DebugAssert(parse_result.size() > 0, "Cannot compile SQL query because it has zero statements.");
+
+  // (2) Collect parse results
+  for (auto* statement : parse_result.releaseStatements()) {
+    // Create shared pointers from raw pointers
+    parsed_sql_statements_.emplace_back(std::make_shared<hsql::SQLParserResult>(statement));
+  }
+
+  // (3) For each parsed SQL statement, create a QueryStatementCompiler with a QueryContext
+
+  // Split the (multi-) statement SQL string into substrings for each statement. These substrings can be used to cache
+  // query plans. The SQLParser only offers the length of the string, so it needs to be split manually.
+  auto sql_string_offset = 0u;
+
+  query_statement_compilers_.reserve(parsed_sql_statements_.size());
+  for (const auto& parsed_sql_statement : parsed_sql_statements_) {
+    parsed_sql_statement->setIsValid(true);
+
+    // We will always have one at 0 because we set it ourselves
+    const auto* statement = parsed_sql_statement->getStatement(0);
+
+    // Check if statement alters the structure of the database in a way that following statements might depend upon.
+    switch (statement->type()) {
+      case hsql::StatementType::kStmtImport:
+      case hsql::StatementType::kStmtCreate:
+      case hsql::StatementType::kStmtDrop:
+      case hsql::StatementType::kStmtAlter:
+      case hsql::StatementType::kStmtRename: {
+        Fail("Altering SQL statements are currently unsupported!");
+      } break;
+      default: { /* do nothing */
+      }
+    }
+
+    const auto statement_string_length = statement->stringLength;
+    const auto statement_string = boost::trim_copy(sql_query_.substr(sql_string_offset, statement_string_length));
+    sql_string_offset += statement_string_length;
+    sql_statement_strings_.emplace_back(statement_string);
+
+    // Create QueryContext
+    auto query_statement_context = std::make_shared<QueryContext>(statement_string, catalog_, target_bucket_name_);
+    query_statement_context->SetTargetFormat(ExportFormat::kCsv);
+    // Create StatementCompiler
+    auto query_statement_compiler =
+        std::make_shared<QueryStatementCompiler>(parsed_sql_statement, query_statement_context);
+    metrics_.statement_metrics.emplace_back(query_statement_compiler->Metrics());
+    query_statement_compilers_.emplace_back(std::move(query_statement_compiler));
+  }
+}
+
+const std::string& QueryCompiler::SqlQueryString() const { return sql_query_; }
+
+size_t QueryCompiler::SqlStatementCount() const { return sql_statement_strings_.size(); }
+
+const std::vector<std::string>& QueryCompiler::SqlStatementStrings() { return sql_statement_strings_; }
+
+const std::vector<std::shared_ptr<hsql::SQLParserResult>>& QueryCompiler::ParsedSqlStatements() const {
+  return parsed_sql_statements_;
+}
+
+std::vector<std::shared_ptr<AbstractLqpNode>> QueryCompiler::GetLqps() {
+  std::vector<std::shared_ptr<AbstractLqpNode>> lqps;
+  lqps.reserve(SqlStatementCount());
+  for (const auto& query_statement_compiler : query_statement_compilers_) {
+    lqps.emplace_back(query_statement_compiler->GetLqp());
+  }
+  return lqps;
+}
+
+std::vector<std::shared_ptr<AbstractLqpNode>> QueryCompiler::GetOptimizedLqps() {
+  std::vector<std::shared_ptr<AbstractLqpNode>> lqps;
+  lqps.reserve(SqlStatementCount());
+  for (const auto& query_statement_compiler : query_statement_compilers_) {
+    lqps.emplace_back(query_statement_compiler->GetOptimizedLqp());
+  }
+  return lqps;
+}
+
+std::vector<std::shared_ptr<AbstractOperatorProxy>> QueryCompiler::GetPqps() {
+  std::vector<std::shared_ptr<AbstractOperatorProxy>> pqps;
+  pqps.reserve(SqlStatementCount());
+  for (const auto& query_statement_compiler : query_statement_compilers_) {
+    pqps.emplace_back(query_statement_compiler->GetPqp());
+  }
+  return pqps;
+}
+
+std::vector<std::shared_ptr<AbstractOperatorProxy>> QueryCompiler::GetOptimizedPqps() {
+  std::vector<std::shared_ptr<AbstractOperatorProxy>> pqps;
+  pqps.reserve(SqlStatementCount());
+  for (const auto& query_statement_compiler : query_statement_compilers_) {
+    pqps.emplace_back(query_statement_compiler->GetOptimizedPqp());
+  }
+  return pqps;
+}
+
+const std::vector<std::shared_ptr<PqpPipeline>>& QueryCompiler::GetPqpPipelines() {
+  // for each PQP: call slicer->GetPipelines, SetPredecessorPipeline
+  Assert(GetOptimizedPqps().size() == 1, "Currently, only one PQP is supported.");
+  if (pqp_pipelines_.empty()) {
+    pqp_pipelines_ = query_statement_compilers_.at(0)->GetPqpPipelines();
+  }
+
+  return pqp_pipelines_;
+}
+
+const QueryCompilerMetrics& QueryCompiler::Metrics() const { return metrics_; }
+
+}  // namespace skyrise

--- a/src/lib/compiler/query_compiler.hpp
+++ b/src/lib/compiler/query_compiler.hpp
@@ -1,0 +1,97 @@
+#pragma once
+
+#include <chrono>
+#include <memory>
+#include <string>
+
+#include <SQLParser.h>
+
+#include "logical_query_plan/abstract_lqp_node.hpp"
+#include "metadata/abstract_catalog.hpp"
+#include "physical_query_plan/abstract_operator_proxy.hpp"
+#include "physical_query_plan/pqp_pipeline.hpp"
+#include "query_statement_compiler.hpp"
+
+namespace skyrise {
+
+struct QueryCompilerMetrics {
+  std::vector<std::shared_ptr<const QueryStatementCompilerMetrics>> statement_metrics;
+
+  // This is different from the other measured times as we only get this for all statements at once.
+  std::chrono::nanoseconds parse_time_nanos{0};
+};
+std::ostream& operator<<(std::ostream& stream, const QueryCompilerMetrics& metrics);
+
+class QueryCompiler : public Noncopyable {
+ public:
+  QueryCompiler(std::string sql_query, std::shared_ptr<AbstractCatalog> catalog,
+                std::string target_bucket_name = "mock_target_bucket");
+
+  /**
+   * @returns the original SQL string.
+   */
+  const std::string& SqlQueryString() const;
+
+  /**
+   * @returns the number of statements in the original SQL string.
+   */
+  size_t SqlStatementCount() const;
+
+  /**
+   * @returns the SQL string for each statement.
+   */
+  const std::vector<std::string>& SqlStatementStrings();
+
+  /**
+   * @returns the SQLParser results for each statement.
+   */
+  const std::vector<std::shared_ptr<hsql::SQLParserResult>>& ParsedSqlStatements() const;
+
+  /**
+   * @returns the unoptimized logical query plan roots for each statement.
+   */
+  std::vector<std::shared_ptr<AbstractLqpNode>> GetLqps();
+
+  /**
+   * @returns the optimized logical query plan roots for each statement.
+   */
+  std::vector<std::shared_ptr<AbstractLqpNode>> GetOptimizedLqps();
+
+  /**
+   * @returns unoptimized physical query plan roots for each statement.
+   */
+  std::vector<std::shared_ptr<AbstractOperatorProxy>> GetPqps();
+
+  /**
+   * @returns unoptimized physical query plan roots for each statement.
+   */
+  std::vector<std::shared_ptr<AbstractOperatorProxy>> GetOptimizedPqps();
+
+  /**
+   * @returns
+   */
+  const std::vector<std::shared_ptr<PqpPipeline>>& GetPqpPipelines();
+
+  const QueryCompilerMetrics& Metrics() const;
+
+ private:
+  // Input data
+  const std::string sql_query_;
+  const std::shared_ptr<AbstractCatalog> catalog_;
+  const std::string target_bucket_name_;
+
+  // Utilities
+  std::vector<std::shared_ptr<QueryStatementCompiler>> query_statement_compilers_;
+  QueryCompilerMetrics metrics_ = {};
+
+  // SQL artifacts
+  std::vector<std::string> sql_statement_strings_;
+  std::vector<std::shared_ptr<hsql::SQLParserResult>> parsed_sql_statements_;
+  std::vector<std::reference_wrapper<const SqlTranslationInfo>> sql_translation_infos_;
+
+  // Plans
+  std::vector<std::shared_ptr<AbstractLqpNode>> optimized_lqps_;
+  std::vector<std::shared_ptr<PqpPipeline>> pqp_pipelines_;
+};
+
+}  // namespace skyrise

--- a/src/lib/compiler/query_statement_compiler.cpp
+++ b/src/lib/compiler/query_statement_compiler.cpp
@@ -1,0 +1,137 @@
+#include "query_statement_compiler.hpp"
+
+#include "logical_query_plan/lqp_translator.hpp"
+#include "optimizer/lqp_optimizer.hpp"
+#include "optimizer/pqp_optimizer.hpp"
+#include "physical_query_plan/export_operator_proxy.hpp"
+#include "physical_query_plan/pqp_pipeline_slicer.hpp"
+#include "physical_query_plan/pqp_utils.hpp"
+#include "sql/sql_translator.hpp"
+#include "utils/timer.hpp"
+
+namespace skyrise {
+
+QueryStatementCompiler::QueryStatementCompiler(std::shared_ptr<hsql::SQLParserResult> parsed_sql_statement,
+                                               std::shared_ptr<QueryContext> query_statement_context)
+    : parsed_sql_statement_(std::move(parsed_sql_statement)),
+      query_statement_context_(std::move(query_statement_context)),
+      metrics_(std::make_shared<QueryStatementCompilerMetrics>()) {}
+
+const std::string& QueryStatementCompiler::SqlStatementString() const {
+  return query_statement_context_->QueryString();
+}
+
+const std::shared_ptr<AbstractLqpNode>& QueryStatementCompiler::GetLqp() {
+  // Assert(!optimized_lqp_, "The LQP is already optimized. Call GetOptimizedLqp().");
+  if (lqp_) {
+    return lqp_;
+  }
+
+  Timer timer;
+  {
+    auto translation_result =
+        SqlTranslator(query_statement_context_->Catalog()).translate_parser_result(*parsed_sql_statement_);
+    DebugAssert(translation_result.lqp_nodes.size() == 1,
+                "LQP translation returned no or more than one LQP root for a single statement.");
+    lqp_ = translation_result.lqp_nodes.front();
+    translation_info_ = std::move(translation_result.translation_info);
+  }
+  metrics_->sql_translation_duration = timer.Lap();
+
+  return lqp_;
+}
+
+const std::shared_ptr<AbstractLqpNode>& QueryStatementCompiler::GetOptimizedLqp() {
+  if (optimized_lqp_) {
+    return optimized_lqp_;
+  }
+
+  auto lqp = GetLqp();
+  // The LqpOptimizer works on the original unoptimized LQP nodes. After optimizing, the unoptimized version is also
+  // optimized, which could lead to subtle bugs. Therefore, we release ownership as follows:
+  lqp_.reset();
+
+  Timer timer;
+  auto lqp_optimizer_metrics = std::make_shared<OptimizerMetrics>();
+  {
+    auto lqp_optimizer = LqpOptimizer::CreateDefaultLqpOptimizer();
+    optimized_lqp_ = lqp_optimizer->Optimize(std::move(lqp), lqp_optimizer_metrics);
+  }
+  metrics_->lqp_optimization_duration = timer.Lap();
+  metrics_->lqp_optimizer_metrics = *lqp_optimizer_metrics;
+
+  return optimized_lqp_;
+}
+
+const std::shared_ptr<AbstractOperatorProxy>& QueryStatementCompiler::GetPqp() {
+  // Assert(!optimized_pqp_, "The PQP is already optimized. Call GetOptimizedPqp().");
+  if (pqp_) {
+    return pqp_;
+  }
+
+  auto optimized_lqp = GetOptimizedLqp();
+  Timer timer;
+  {
+    // (1) Translate LQP
+    const auto pqp_result = LqpTranslator(query_statement_context_).TranslateNode(optimized_lqp);
+    // (2) Generate S3 path for the final result
+    std::stringstream target_key_stream;
+    target_key_stream << query_statement_context_->FinalResultsKeyPrefix();
+    target_key_stream << query_statement_context_->QueryIdentity() << "_final_result";
+    target_key_stream << query_statement_context_->TargetFileExtension();
+    // (3) Define Export for final result
+    const auto pqp_with_export =
+        ExportOperatorProxy::Make(query_statement_context_->TargetBucketName(), target_key_stream.str(),
+                                  query_statement_context_->TargetFormat(), pqp_result);
+    pqp_ = std::static_pointer_cast<AbstractOperatorProxy>(pqp_with_export);
+    // (4) Prefix all operator proxies in PQP
+    PrefixOperatorProxyIdentities(pqp_, query_statement_context_->QueryIdentity());
+  }
+  metrics_->lqp_translation_duration = timer.Lap();
+
+  return pqp_;
+}
+
+const std::shared_ptr<AbstractOperatorProxy>& QueryStatementCompiler::GetOptimizedPqp() {
+  if (optimized_pqp_) {
+    return optimized_pqp_;
+  }
+
+  auto pqp = GetPqp();
+  // The PqpOptimizer works on the original unoptimized PQP nodes. After optimizing, the unoptimized version is also
+  // optimized, which could lead to subtle bugs. Therefore, we release ownership as follows:
+  pqp_.reset();
+
+  Timer timer;
+  auto pqp_optimizer_metrics = std::make_shared<OptimizerMetrics>();
+  {
+    auto pqp_optimizer = PqpOptimizer::CreateDefaultPqpOptimizer();
+    optimized_pqp_ = pqp_optimizer->Optimize(std::move(pqp));
+  }
+  metrics_->pqp_optimization_duration = timer.Lap();
+  metrics_->pqp_optimizer_metrics = *pqp_optimizer_metrics;
+
+  return optimized_pqp_;
+}
+
+const std::vector<std::shared_ptr<PqpPipeline>>& QueryStatementCompiler::GetPqpPipelines() {
+  if (!pqp_pipelines_.empty()) {
+    return pqp_pipelines_;
+  }
+
+  auto pqp = GetOptimizedPqp();
+  optimized_pqp_.reset();
+
+  Timer timer;
+  {
+    auto pipeline_slicer = PqpPipelineSlicer(std::move(pqp), query_statement_context_);
+    pqp_pipelines_ = pipeline_slicer.GetPipelines();
+  }
+  metrics_->pqp_slicing_duration = timer.Lap();
+
+  return pqp_pipelines_;
+}
+
+const std::shared_ptr<QueryStatementCompilerMetrics>& QueryStatementCompiler::Metrics() const { return metrics_; }
+
+}  // namespace skyrise

--- a/src/lib/compiler/query_statement_compiler.hpp
+++ b/src/lib/compiler/query_statement_compiler.hpp
@@ -1,0 +1,84 @@
+#pragma once
+
+#include <chrono>
+#include <memory>
+#include <string>
+
+#include <SQLParser.h>
+
+#include "logical_query_plan/abstract_lqp_node.hpp"
+#include "optimizer/abstract_optimizer.hpp"
+#include "physical_query_plan/abstract_operator_proxy.hpp"
+#include "physical_query_plan/pqp_pipeline.hpp"
+#include "query_context.hpp"
+#include "sql/sql_translator.hpp"
+
+namespace skyrise {
+
+struct QueryStatementCompilerMetrics {
+  // SQL Translation
+  std::chrono::nanoseconds sql_translation_duration;
+  std::chrono::nanoseconds lqp_translation_duration;
+  // LQP
+  std::chrono::nanoseconds lqp_optimization_duration;
+  OptimizerMetrics lqp_optimizer_metrics;
+  // PQP
+  std::chrono::nanoseconds pqp_optimization_duration;
+  OptimizerMetrics pqp_optimizer_metrics;
+  std::chrono::nanoseconds pqp_slicing_duration;
+};
+
+/**
+ * Doc
+ */
+class QueryStatementCompiler : public Noncopyable {
+ public:
+  QueryStatementCompiler(std::shared_ptr<hsql::SQLParserResult> parsed_sql_statement,
+                         std::shared_ptr<QueryContext> query_statement_context);
+
+  /**
+   * @returns the SQL string of this particular statement
+   */
+  [[nodiscard]] const std::string& SqlStatementString() const;
+
+  /**
+   * @returns an unoptimized logical query plan from the SQL statement
+   */
+  const std::shared_ptr<AbstractLqpNode>& GetLqp();
+  const std::shared_ptr<AbstractLqpNode>& GetOptimizedLqp();
+
+  /**
+   * Uses the optimized logical query plan to create a physical query plan that can be executed on a single worker.
+   */
+  const std::shared_ptr<AbstractOperatorProxy>& GetPqp();
+
+  /**
+   * Uses the "vanilla" physical query plan and optimizes it for distributed execution with multiple independent
+   * workers.
+   */
+  const std::shared_ptr<AbstractOperatorProxy>& GetOptimizedPqp();
+
+  /**
+   * Uses the optimized phyiscal query plan and slices it into PqpPipelines for distributed execution.
+   */
+  const std::vector<std::shared_ptr<PqpPipeline>>& GetPqpPipelines();
+
+  const std::shared_ptr<QueryStatementCompilerMetrics>& Metrics() const;
+
+ private:
+  // SQL
+  std::shared_ptr<hsql::SQLParserResult> parsed_sql_statement_;
+  SqlTranslationInfo translation_info_;
+
+  // Plans
+  std::shared_ptr<AbstractLqpNode> lqp_;
+  std::shared_ptr<AbstractLqpNode> optimized_lqp_;
+  std::shared_ptr<AbstractOperatorProxy> pqp_;
+  std::shared_ptr<AbstractOperatorProxy> optimized_pqp_;
+  std::vector<std::shared_ptr<PqpPipeline>> pqp_pipelines_;
+
+  std::shared_ptr<QueryContext> query_statement_context_;
+  std::shared_ptr<QueryStatementCompilerMetrics> metrics_;
+};
+
+}  // namespace skyrise

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -20,6 +20,7 @@ set(
     benchmark/lib/tpch/tpch_data_generator_test.cpp
 
     lib/compiler/compilation_context_test.cpp
+    lib/compiler/query_compiler_test.cpp
 
     lib/compiler/physical_query_plan/operator_proxy/aggregate_operator_proxy_test.cpp
     lib/compiler/physical_query_plan/operator_proxy/alias_operator_proxy_test.cpp

--- a/src/test/lib/compiler/query_compiler_test.cpp
+++ b/src/test/lib/compiler/query_compiler_test.cpp
@@ -15,13 +15,13 @@
 #include "compiler/logical_query_plan/projection_node.hpp"
 #include "compiler/logical_query_plan/stored_table_node.hpp"
 #include "expression/expression_functional.hpp"
-#include "metadata/remote_catalog.hpp"
+#include "metadata/remote_catalog.hpp" // TODO Adopt glue_catalog.hpp
 #include "metadata/table_schema.hpp"
 #include "metadata/tpch_mock_catalog.hpp"
 #include "testing/testing_assert.hpp"
 #include "tpch/tpch_query_generator.hpp"
-#include "visualization/lqp_visualizer.hpp"
-#include "visualization/pqp_visualizer.hpp"
+//#include "visualization/lqp_visualizer.hpp"
+//#include "visualization/pqp_visualizer.hpp"
 
 namespace {
 using namespace skyrise;  // NOLINT(google-build-using-namespace)
@@ -29,6 +29,7 @@ using namespace skyrise;  // NOLINT(google-build-using-namespace)
 const std::string kTableNameLineitem = "lineitem";
 const std::string kTpchDatabaseNameSF1000 = "CI_TPCH_SF1000_Database";
 
+// Consider removing visualization stuff – relict from master's thesis.
 void VisualizePlans(QueryCompiler& query_compiler, const std::string& query_name) {
   std::cout << *query_compiler.GetOptimizedLqps().front() << std::endl;
   std::cout << *query_compiler.GetOptimizedPqps().front() << std::endl;

--- a/src/test/lib/compiler/query_compiler_test.cpp
+++ b/src/test/lib/compiler/query_compiler_test.cpp
@@ -1,0 +1,421 @@
+/**
+ * Taken and modified from our sister project Hyrise (https://github.com/hyrise/hyrise)
+ */
+#include "compiler/query_compiler.hpp"
+
+#include <memory>
+#include <string>
+
+#include <gtest/gtest.h>
+
+#include "client/client.hpp"
+#include "compiler/logical_query_plan/alias_node.hpp"
+#include "compiler/logical_query_plan/join_node.hpp"
+#include "compiler/logical_query_plan/predicate_node.hpp"
+#include "compiler/logical_query_plan/projection_node.hpp"
+#include "compiler/logical_query_plan/stored_table_node.hpp"
+#include "expression/expression_functional.hpp"
+#include "metadata/remote_catalog.hpp"
+#include "metadata/table_schema.hpp"
+#include "metadata/tpch_mock_catalog.hpp"
+#include "testing/testing_assert.hpp"
+#include "tpch/tpch_query_generator.hpp"
+#include "visualization/lqp_visualizer.hpp"
+#include "visualization/pqp_visualizer.hpp"
+
+namespace {
+using namespace skyrise;  // NOLINT(google-build-using-namespace)
+
+const std::string kTableNameLineitem = "lineitem";
+const std::string kTpchDatabaseNameSF1000 = "CI_TPCH_SF1000_Database";
+
+void VisualizePlans(QueryCompiler& query_compiler, const std::string& query_name) {
+  // std::cout << *query_compiler.GetOptimizedLqps().front() << std::endl;
+  std::cout << *query_compiler.GetOptimizedPqps().front() << std::endl;
+
+  const std::string prefix = "Plan_" + query_name;
+  GraphvizConfig graphviz_config;
+  const std::string format = "dot";
+  graphviz_config.format = format;
+  LqpVisualizer{graphviz_config}.Visualize(query_compiler.GetLqps(), prefix + "_LQP." + format);
+  LqpVisualizer{graphviz_config}.Visualize(query_compiler.GetOptimizedLqps(), prefix + "_LQP_optimized." + format);
+  PqpVisualizer{graphviz_config}.Visualize(query_compiler.GetPqps(), prefix + "_PQP." + format);
+  PqpVisualizer{graphviz_config}.Visualize(query_compiler.GetOptimizedPqps(), prefix + "_PQP_optimized." + format);
+  for (const auto& pipeline : query_compiler.GetPqpPipelines()) {
+    std::string file_name = prefix;
+    file_name.append("_").append(pipeline->Identity()).append(".").append(format);
+    PqpVisualizer{graphviz_config}.Visualize(pipeline->GetFragments(), file_name);
+  }
+}
+
+}  // namespace
+
+namespace skyrise {
+using namespace skyrise::expression_functional;  // NOLINT(google-build-using-namespace)
+
+class QueryCompilerTest : public ::testing::Test {
+ public:
+  static void SetUpTestSuite() {
+    catalog_ = std::make_shared<TpchMockCatalog>();
+    catalog_->AddTableSchemaFromFileHeader("table_a", "resources/test_data/tbl/int_float.tbl");
+    catalog_->AddTableSchemaFromFileHeader("table_b", "resources/test_data/tbl/int_float2.tbl");
+  }
+
+ protected:
+  static inline std::shared_ptr<MockCatalog> catalog_;
+  // clang-format off
+  const std::string join_query_ = R"(SELECT table_a.a, table_a.b, table_b.b AS bb
+                                     FROM table_a, table_b
+                                     WHERE table_a.a = table_b.a AND table_a.a > 1000)";
+  // clang-format on
+};
+
+class AwsQueryCompilerTest : public ::testing::Test {
+ public:
+  void SetUp() override {
+    Aws::InitAPI(sdk_options_);
+    client_ = std::make_shared<Client>();
+
+    catalog_ = std::make_shared<RemoteCatalog>(client_, std::vector<std::string>(), kTpchDatabaseNameSF1000);
+    if (!catalog_->TableExists(kTableNameLineitem)) {
+      catalog_->CreateDatabase();
+      TpchMockCatalog tpch_mock_catalog;
+      catalog_->AddTable(kTableNameLineitem, tpch_mock_catalog.GetTableSchema("lineitem"), "skyrise-tpch-lineitem-data",
+                         "s1000");
+      Assert(catalog_->TableExists(kTableNameLineitem), "RemoteCatalog does not return lineitem table data.");
+    }
+  }
+
+  void TearDown() override { Aws::ShutdownAPI(sdk_options_); }
+
+ protected:
+  std::shared_ptr<Client> client_;
+  std::shared_ptr<RemoteCatalog> catalog_;
+
+ private:
+  Aws::SDKOptions sdk_options_;
+};
+
+TEST_F(QueryCompilerTest, CreateSingleStatement) {
+  const std::string select_query_a = "SELECT * FROM table_a";
+  auto query_compiler = QueryCompiler(select_query_a, catalog_);
+
+  EXPECT_EQ(query_compiler.SqlStatementCount(), 1);
+  EXPECT_EQ(query_compiler.SqlQueryString(), select_query_a);
+  EXPECT_EQ(query_compiler.SqlStatementStrings().at(0), select_query_a);
+}
+
+TEST_F(QueryCompilerTest, CreateSingleStatementWithJoin) {
+  auto query_compiler = QueryCompiler(join_query_, catalog_);
+
+  EXPECT_EQ(query_compiler.SqlStatementCount(), 1);
+  EXPECT_EQ(query_compiler.SqlQueryString(), join_query_);
+  EXPECT_EQ(query_compiler.SqlStatementStrings().at(0), join_query_);
+}
+
+TEST_F(QueryCompilerTest, CreateMultiStatement) {
+  const std::string multi_statement_dependant = "SELECT * FROM table_a; SELECT * FROM table_b;";
+  auto query_compiler = QueryCompiler(multi_statement_dependant, catalog_);
+
+  EXPECT_EQ(query_compiler.SqlStatementCount(), 2);
+  EXPECT_EQ(query_compiler.SqlQueryString(), multi_statement_dependant);
+  EXPECT_EQ(query_compiler.SqlStatementStrings().at(0), "SELECT * FROM table_a;");
+  EXPECT_EQ(query_compiler.SqlStatementStrings().at(1), "SELECT * FROM table_b;");
+}
+
+TEST_F(QueryCompilerTest, GetParsedSQL) {
+  auto query_compiler = QueryCompiler("SELECT * FROM table_a", catalog_);
+  const auto& parsed_sql = query_compiler.ParsedSqlStatements().at(0);
+
+  EXPECT_TRUE(parsed_sql->isValid());
+  auto statements = parsed_sql->getStatements();
+  EXPECT_EQ(statements.size(), 1u);
+  EXPECT_EQ(statements.at(0)->type(), hsql::StatementType::kStmtSelect);
+}
+
+TEST_F(QueryCompilerTest, GetUnoptimizedLqp) {
+  auto query_compiler = QueryCompiler("SELECT * FROM table_a", catalog_);
+
+  const auto expected_lqp = StoredTableNode::Make("table_a", catalog_);
+
+  EXPECT_LQP_EQ(query_compiler.GetOptimizedLqps().at(0), expected_lqp);
+}
+
+TEST_F(QueryCompilerTest, GetUnoptimizedLqpWithJoin) {
+  auto query_compiler = QueryCompiler(join_query_, catalog_);
+
+  const auto lqp = query_compiler.GetOptimizedLqps().at(0);
+  EXPECT_TRUE(lqp);
+
+  const auto stored_table_node_a = StoredTableNode::Make("table_a", catalog_);
+  const auto a_a = stored_table_node_a->get_column("a");
+  const auto a_b = stored_table_node_a->get_column("b");
+  const auto stored_table_node_b = StoredTableNode::Make("table_b", catalog_);
+  const auto b_a = stored_table_node_b->get_column("a");
+  const auto b_b = stored_table_node_b->get_column("b");
+
+  // clang-format off
+  auto expected_lqp =
+  AliasNode::Make(ExpressionVector_(a_a, a_b, b_b), std::vector<std::string>({"a", "b", "bb"}),
+    ProjectionNode::Make(ExpressionVector_(a_a, a_b, b_b),
+      PredicateNode::Make(Equals_(a_a, b_a),
+        PredicateNode::Make(GreaterThan_(a_a, Value_(1000)),
+          JoinNode::Make(JoinMode::kCross,
+            stored_table_node_a,
+            stored_table_node_b)))));
+
+  // clang-format on
+  EXPECT_LQP_EQ(lqp, expected_lqp);
+}
+
+TEST_F(QueryCompilerTest, Metrics) {
+  const auto zero_duration = std::chrono::nanoseconds::zero();
+
+  auto query_compiler = QueryCompiler("SELECT * FROM table_a", catalog_);
+  const auto& metrics = query_compiler.Metrics();
+  const auto& statement_metrics = metrics.statement_metrics.at(0);
+
+  EXPECT_GT(metrics.parse_time_nanos, zero_duration);
+  EXPECT_EQ(statement_metrics->sql_translation_duration, zero_duration);
+  EXPECT_EQ(statement_metrics->lqp_optimization_duration, zero_duration);
+  EXPECT_EQ(statement_metrics->lqp_translation_duration, zero_duration);
+  EXPECT_EQ(statement_metrics->pqp_optimization_duration, zero_duration);
+  EXPECT_EQ(statement_metrics->pqp_slicing_duration, zero_duration);
+
+  // Run to get times
+  EXPECT_EQ(query_compiler.GetPqpPipelines().size(), 1);
+
+  EXPECT_GT(statement_metrics->sql_translation_duration, zero_duration);
+  EXPECT_GT(statement_metrics->lqp_optimization_duration, zero_duration);
+  EXPECT_GT(statement_metrics->lqp_translation_duration, zero_duration);
+  EXPECT_GT(statement_metrics->pqp_optimization_duration, zero_duration);
+  EXPECT_GT(statement_metrics->pqp_slicing_duration, zero_duration);
+}
+
+/**
+ * // TODO(julianmenzler): Enable after implementing PlaceholderExpression
+TEST_F(QueryCompilerTest, SqlTranslationInfo) {
+  {
+    auto query_compiler = QueryCompiler{"SELECT * FROM table_a"};
+    auto translation_info = get_sql_pipeline_statements(sql_pipeline).at(0)->get_sql_translation_info();
+
+    EXPECT_TRUE(translation_info.parameter_ids_of_value_placeholders.empty());
+  }
+
+  {
+    auto query_compiler = QueryCompiler{"SELECT * FROM table_a WHERE a > ? AND b BETWEEN 5 AND ?"};
+    auto translation_info = get_sql_pipeline_statements(sql_pipeline).at(0)->get_sql_translation_info();
+
+    const auto parameters = std::vector<ParameterID>{ParameterID(0), ParameterID(1)};
+    EXPECT_EQ(translation_info.parameter_ids_of_value_placeholders, parameters);
+  }
+
+  {
+    auto query_compiler =
+        QueryCompiler{
+            "SELECT * FROM table_a t1 WHERE a > ? AND b = (SELECT MAX(b) FROM table_a t2 WHERE t2.a = t1.a AND b > ?)"};
+    auto translation_info = get_sql_pipeline_statements(sql_pipeline).at(0)->get_sql_translation_info();
+
+    const auto parameters = std::vector<ParameterID>{ParameterID(0), ParameterID(2)};
+    EXPECT_EQ(translation_info.parameter_ids_of_value_placeholders, parameters);
+  }
+}
+*/
+
+TEST_F(QueryCompilerTest, TpchQ1) {
+  auto q1 = TpchQueryGenerator::BuildDeterministicQuery(0);
+  auto query_compiler = QueryCompiler(q1, catalog_);
+  EXPECT_EQ(query_compiler.GetOptimizedLqps().size(), 1);
+  EXPECT_EQ(query_compiler.GetOptimizedPqps().size(), 1);
+  EXPECT_EQ(query_compiler.GetPqpPipelines().size(), 2);
+  //  VisualizePlans(query_compiler, "TpchQ1");
+}
+
+TEST_F(AwsQueryCompilerTest, TpchQ1) {
+  auto q1 = TpchQueryGenerator::BuildDeterministicQuery(0);
+  auto query_compiler = QueryCompiler(q1, catalog_);  // SF 1000
+  EXPECT_EQ(query_compiler.GetOptimizedLqps().size(), 1);
+  EXPECT_EQ(query_compiler.GetOptimizedPqps().size(), 1);
+  //  EXPECT_EQ(query_compiler.GetPqpPipelines().size(), xx);
+  //  VisualizePlans(query_compiler, "Aws_TpchQ1");
+}
+
+TEST_F(QueryCompilerTest, DISABLED_TpchQ2) {  // misses hsql::kExprSelect
+  auto q2 = TpchQueryGenerator::BuildDeterministicQuery(1);
+  auto query_compiler = QueryCompiler(q2, catalog_);
+  EXPECT_EQ(query_compiler.GetOptimizedLqps().size(), 1);
+  EXPECT_EQ(query_compiler.GetOptimizedPqps().size(), 1);
+  VisualizePlans(query_compiler, "TpchQ2");
+}
+
+TEST_F(QueryCompilerTest, TpchQ3) {
+  auto q3 = TpchQueryGenerator::BuildDeterministicQuery(2);
+  auto query_compiler = QueryCompiler(q3, catalog_);
+  EXPECT_EQ(query_compiler.GetOptimizedLqps().size(), 1);
+  EXPECT_EQ(query_compiler.GetOptimizedPqps().size(), 1);
+  //  VisualizePlans(query_compiler, "TpchQ3");
+}
+
+TEST_F(QueryCompilerTest, DISABLED_TpchQ4) {  // misses hsql::kOpExists:
+  auto q4 = TpchQueryGenerator::BuildDeterministicQuery(3);
+  auto query_compiler = QueryCompiler(q4, catalog_);
+  EXPECT_EQ(query_compiler.GetOptimizedLqps().size(), 1);
+  EXPECT_EQ(query_compiler.GetOptimizedPqps().size(), 1);
+  VisualizePlans(query_compiler, "TpchQ4");
+}
+
+TEST_F(QueryCompilerTest, TpchQ5) {
+  auto q5 = TpchQueryGenerator::BuildDeterministicQuery(4);
+  auto query_compiler = QueryCompiler(q5, catalog_);
+  EXPECT_EQ(query_compiler.GetOptimizedLqps().size(), 1);
+  EXPECT_EQ(query_compiler.GetOptimizedPqps().size(), 1);
+  //  VisualizePlans(query_compiler, "TpchQ5");
+}
+
+TEST_F(QueryCompilerTest, TpchQ6) {
+  auto q6 = TpchQueryGenerator::BuildDeterministicQuery(5);
+  auto query_compiler = QueryCompiler(q6, catalog_);
+  EXPECT_EQ(query_compiler.GetOptimizedLqps().size(), 1);
+  EXPECT_EQ(query_compiler.GetOptimizedPqps().size(), 1);
+  EXPECT_EQ(query_compiler.GetPqpPipelines().size(), 2);
+  //  VisualizePlans(query_compiler, "TpchQ6");
+}
+
+TEST_F(AwsQueryCompilerTest, TpchQ6) {
+  auto q6 = TpchQueryGenerator::BuildDeterministicQuery(5);
+  auto query_compiler = QueryCompiler(q6, catalog_);  // SF 1000
+  EXPECT_EQ(query_compiler.GetOptimizedLqps().size(), 1);
+  EXPECT_EQ(query_compiler.GetOptimizedPqps().size(), 1);
+  //  EXPECT_EQ(query_compiler.GetPqpPipelines().size(), xx);
+  //  VisualizePlans(query_compiler, "Aws_TpchQ6");
+}
+
+TEST_F(QueryCompilerTest, DISABLED_TpchQ7) {  // misses FunctionExpression
+  auto q7 = TpchQueryGenerator::BuildDeterministicQuery(6);
+  auto query_compiler = QueryCompiler(q7, catalog_);
+  EXPECT_EQ(query_compiler.GetOptimizedLqps().size(), 1);
+  EXPECT_EQ(query_compiler.GetOptimizedPqps().size(), 1);
+  VisualizePlans(query_compiler, "TpchQ7");
+}
+
+TEST_F(QueryCompilerTest, DISABLED_TpchQ8) {  // misses FunctionExpression
+  auto q8 = TpchQueryGenerator::BuildDeterministicQuery(7);
+  auto query_compiler = QueryCompiler(q8, catalog_);
+  EXPECT_EQ(query_compiler.GetOptimizedLqps().size(), 1);
+  EXPECT_EQ(query_compiler.GetOptimizedPqps().size(), 1);
+  VisualizePlans(query_compiler, "TpchQ8");
+}
+
+TEST_F(QueryCompilerTest, DISABLED_TpchQ9) {  // misses FunctionExpression
+  auto q9 = TpchQueryGenerator::BuildDeterministicQuery(8);
+  auto query_compiler = QueryCompiler(q9, catalog_);
+  EXPECT_EQ(query_compiler.GetOptimizedLqps().size(), 1);
+  EXPECT_EQ(query_compiler.GetOptimizedPqps().size(), 1);
+  VisualizePlans(query_compiler, "TpchQ9");
+}
+
+TEST_F(QueryCompilerTest, TpchQ10) {
+  auto q10 = TpchQueryGenerator::BuildDeterministicQuery(9);
+  auto query_compiler = QueryCompiler(q10, catalog_);
+  EXPECT_EQ(query_compiler.GetOptimizedLqps().size(), 1);
+  EXPECT_EQ(query_compiler.GetOptimizedPqps().size(), 1);
+  //  VisualizePlans(query_compiler, "TpchQ10");
+}
+
+TEST_F(QueryCompilerTest, DISABLED_TpchQ11) {  // misses hsql::kExprSelect
+  auto q11 = TpchQueryGenerator::BuildDeterministicQuery(10);
+  auto query_compiler = QueryCompiler(q11, catalog_);
+  EXPECT_EQ(query_compiler.GetOptimizedLqps().size(), 1);
+  EXPECT_EQ(query_compiler.GetOptimizedPqps().size(), 1);
+  VisualizePlans(query_compiler, "TpchQ11");
+}
+
+TEST_F(QueryCompilerTest, DISABLED_TpchQ12) {  // misses CaseExpression
+  auto q12 = TpchQueryGenerator::BuildDeterministicQuery(11);
+  auto query_compiler = QueryCompiler(q12, catalog_);
+  EXPECT_EQ(query_compiler.GetOptimizedLqps().size(), 1);
+  EXPECT_EQ(query_compiler.GetOptimizedPqps().size(), 1);
+  VisualizePlans(query_compiler, "TpchQ12");
+}
+
+TEST_F(QueryCompilerTest, TpchQ13) {
+  auto q13 = TpchQueryGenerator::BuildDeterministicQuery(12);
+  auto query_compiler = QueryCompiler(q13, catalog_);
+  EXPECT_EQ(query_compiler.GetOptimizedLqps().size(), 1);
+  EXPECT_EQ(query_compiler.GetOptimizedPqps().size(), 1);
+  //  VisualizePlans(query_compiler, "TpchQ13");
+}
+
+TEST_F(QueryCompilerTest, DISABLED_TpchQ14) {  // misses CaseExpression
+  auto q14 = TpchQueryGenerator::BuildDeterministicQuery(13);
+  auto query_compiler = QueryCompiler(q14, catalog_);
+  EXPECT_EQ(query_compiler.GetOptimizedLqps().size(), 1);
+  EXPECT_EQ(query_compiler.GetOptimizedPqps().size(), 1);
+  VisualizePlans(query_compiler, "TpchQ14");
+}
+
+TEST_F(QueryCompilerTest, DISABLED_TpchQ15) {  // misses view multi-statement, view-functionality
+  auto q15 = TpchQueryGenerator::BuildDeterministicQuery(14);
+  auto query_compiler = QueryCompiler(q15, catalog_);
+  EXPECT_EQ(query_compiler.GetOptimizedLqps().size(), 1);
+  EXPECT_EQ(query_compiler.GetOptimizedPqps().size(), 1);
+  VisualizePlans(query_compiler, "TpchQ15");
+}
+
+TEST_F(QueryCompilerTest, DISABLED_TpchQ16) {  // misses `a IN (x, y, z)`
+  auto q16 = TpchQueryGenerator::BuildDeterministicQuery(15);
+  auto query_compiler = QueryCompiler(q16, catalog_);
+  EXPECT_EQ(query_compiler.GetOptimizedLqps().size(), 1);
+  EXPECT_EQ(query_compiler.GetOptimizedPqps().size(), 1);
+  VisualizePlans(query_compiler, "TpchQ16");
+}
+
+TEST_F(QueryCompilerTest, DISABLED_TpchQ17) {  // misses hsql::kExprSelect
+  auto q17 = TpchQueryGenerator::BuildDeterministicQuery(16);
+  auto query_compiler = QueryCompiler(q17, catalog_);
+  EXPECT_EQ(query_compiler.GetOptimizedLqps().size(), 1);
+  EXPECT_EQ(query_compiler.GetOptimizedPqps().size(), 1);
+  VisualizePlans(query_compiler, "TpchQ17");
+}
+
+TEST_F(QueryCompilerTest, DISABLED_TpchQ18) {  // misses a IN (SELECT ...)
+  auto q18 = TpchQueryGenerator::BuildDeterministicQuery(17);
+  auto query_compiler = QueryCompiler(q18, catalog_);
+  EXPECT_EQ(query_compiler.GetOptimizedLqps().size(), 1);
+  EXPECT_EQ(query_compiler.GetOptimizedPqps().size(), 1);
+  VisualizePlans(query_compiler, "TpchQ18");
+}
+
+TEST_F(QueryCompilerTest, DISABLED_TpchQ19) {  // misses `a IN (x, y, z)`
+  auto q19 = TpchQueryGenerator::BuildDeterministicQuery(18);
+  auto query_compiler = QueryCompiler(q19, catalog_);
+  EXPECT_EQ(query_compiler.GetOptimizedLqps().size(), 1);
+  EXPECT_EQ(query_compiler.GetOptimizedPqps().size(), 1);
+  VisualizePlans(query_compiler, "TpchQ19");
+}
+
+TEST_F(QueryCompilerTest, DISABLED_TpchQ20) {  // misses `a IN (SELECT ...)`
+  auto q20 = TpchQueryGenerator::BuildDeterministicQuery(19);
+  auto query_compiler = QueryCompiler(q20, catalog_);
+  EXPECT_EQ(query_compiler.GetOptimizedLqps().size(), 1);
+  EXPECT_EQ(query_compiler.GetOptimizedPqps().size(), 1);
+  VisualizePlans(query_compiler, "TpchQ20");
+}
+
+TEST_F(QueryCompilerTest, DISABLED_TpchQ21) {  // misses hsql::kOpExists
+  auto q21 = TpchQueryGenerator::BuildDeterministicQuery(20);
+  auto query_compiler = QueryCompiler(q21, catalog_);
+  EXPECT_EQ(query_compiler.GetOptimizedLqps().size(), 1);
+  EXPECT_EQ(query_compiler.GetOptimizedPqps().size(), 1);
+  VisualizePlans(query_compiler, "TpchQ21");
+}
+
+TEST_F(QueryCompilerTest, DISABLED_TpchQ22) {  // misses FunctionExpression
+  auto q22 = TpchQueryGenerator::BuildDeterministicQuery(21);
+  auto query_compiler = QueryCompiler(q22, catalog_);
+  EXPECT_EQ(query_compiler.GetOptimizedLqps().size(), 1);
+  EXPECT_EQ(query_compiler.GetOptimizedPqps().size(), 1);
+  VisualizePlans(query_compiler, "TpchQ22");
+}
+
+}  // namespace skyrise

--- a/src/test/lib/compiler/query_compiler_test.cpp
+++ b/src/test/lib/compiler/query_compiler_test.cpp
@@ -30,22 +30,23 @@ const std::string kTableNameLineitem = "lineitem";
 const std::string kTpchDatabaseNameSF1000 = "CI_TPCH_SF1000_Database";
 
 void VisualizePlans(QueryCompiler& query_compiler, const std::string& query_name) {
-  // std::cout << *query_compiler.GetOptimizedLqps().front() << std::endl;
+  std::cout << *query_compiler.GetOptimizedLqps().front() << std::endl;
   std::cout << *query_compiler.GetOptimizedPqps().front() << std::endl;
 
-  const std::string prefix = "Plan_" + query_name;
-  GraphvizConfig graphviz_config;
-  const std::string format = "dot";
-  graphviz_config.format = format;
-  LqpVisualizer{graphviz_config}.Visualize(query_compiler.GetLqps(), prefix + "_LQP." + format);
-  LqpVisualizer{graphviz_config}.Visualize(query_compiler.GetOptimizedLqps(), prefix + "_LQP_optimized." + format);
-  PqpVisualizer{graphviz_config}.Visualize(query_compiler.GetPqps(), prefix + "_PQP." + format);
-  PqpVisualizer{graphviz_config}.Visualize(query_compiler.GetOptimizedPqps(), prefix + "_PQP_optimized." + format);
-  for (const auto& pipeline : query_compiler.GetPqpPipelines()) {
-    std::string file_name = prefix;
-    file_name.append("_").append(pipeline->Identity()).append(".").append(format);
-    PqpVisualizer{graphviz_config}.Visualize(pipeline->GetFragments(), file_name);
-  }
+  // Create SVG plan visualization
+
+//  const std::string prefix = "Plan_" + query_name;
+//  GraphvizConfig graphviz_config;
+//  graphviz_config.format = "svg";
+//  LqpVisualizer{graphviz_config}.Visualize(query_compiler.GetLqps(), prefix + "_LQP." + format);
+//  LqpVisualizer{graphviz_config}.Visualize(query_compiler.GetOptimizedLqps(), prefix + "_LQP_optimized." + format);
+//  PqpVisualizer{graphviz_config}.Visualize(query_compiler.GetPqps(), prefix + "_PQP." + format);
+//  PqpVisualizer{graphviz_config}.Visualize(query_compiler.GetOptimizedPqps(), prefix + "_PQP_optimized." + format);
+//  for (const auto& pipeline : query_compiler.GetPqpPipelines()) {
+//    std::string file_name = prefix;
+//    file_name.append("_").append(pipeline->Identity()).append(".").append(format);
+//    PqpVisualizer{graphviz_config}.Visualize(pipeline->GetFragments(), file_name);
+//  }
 }
 
 }  // namespace
@@ -193,7 +194,7 @@ TEST_F(QueryCompilerTest, Metrics) {
 }
 
 /**
- * // TODO(julianmenzler): Enable after implementing PlaceholderExpression
+ * // TODO(): Enable after implementing PlaceholderExpression
 TEST_F(QueryCompilerTest, SqlTranslationInfo) {
   {
     auto query_compiler = QueryCompiler{"SELECT * FROM table_a"};
@@ -237,7 +238,7 @@ TEST_F(AwsQueryCompilerTest, TpchQ1) {
   EXPECT_EQ(query_compiler.GetOptimizedLqps().size(), 1);
   EXPECT_EQ(query_compiler.GetOptimizedPqps().size(), 1);
   //  EXPECT_EQ(query_compiler.GetPqpPipelines().size(), xx);
-  //  VisualizePlans(query_compiler, "Aws_TpchQ1");
+  VisualizePlans(query_compiler, "Aws_TpchQ1");
 }
 
 TEST_F(QueryCompilerTest, DISABLED_TpchQ2) {  // misses hsql::kExprSelect
@@ -253,7 +254,7 @@ TEST_F(QueryCompilerTest, TpchQ3) {
   auto query_compiler = QueryCompiler(q3, catalog_);
   EXPECT_EQ(query_compiler.GetOptimizedLqps().size(), 1);
   EXPECT_EQ(query_compiler.GetOptimizedPqps().size(), 1);
-  //  VisualizePlans(query_compiler, "TpchQ3");
+  VisualizePlans(query_compiler, "TpchQ3");
 }
 
 TEST_F(QueryCompilerTest, DISABLED_TpchQ4) {  // misses hsql::kOpExists:
@@ -269,7 +270,7 @@ TEST_F(QueryCompilerTest, TpchQ5) {
   auto query_compiler = QueryCompiler(q5, catalog_);
   EXPECT_EQ(query_compiler.GetOptimizedLqps().size(), 1);
   EXPECT_EQ(query_compiler.GetOptimizedPqps().size(), 1);
-  //  VisualizePlans(query_compiler, "TpchQ5");
+  VisualizePlans(query_compiler, "TpchQ5");
 }
 
 TEST_F(QueryCompilerTest, TpchQ6) {
@@ -278,7 +279,7 @@ TEST_F(QueryCompilerTest, TpchQ6) {
   EXPECT_EQ(query_compiler.GetOptimizedLqps().size(), 1);
   EXPECT_EQ(query_compiler.GetOptimizedPqps().size(), 1);
   EXPECT_EQ(query_compiler.GetPqpPipelines().size(), 2);
-  //  VisualizePlans(query_compiler, "TpchQ6");
+  VisualizePlans(query_compiler, "TpchQ6");
 }
 
 TEST_F(AwsQueryCompilerTest, TpchQ6) {
@@ -287,7 +288,7 @@ TEST_F(AwsQueryCompilerTest, TpchQ6) {
   EXPECT_EQ(query_compiler.GetOptimizedLqps().size(), 1);
   EXPECT_EQ(query_compiler.GetOptimizedPqps().size(), 1);
   //  EXPECT_EQ(query_compiler.GetPqpPipelines().size(), xx);
-  //  VisualizePlans(query_compiler, "Aws_TpchQ6");
+  VisualizePlans(query_compiler, "Aws_TpchQ6");
 }
 
 TEST_F(QueryCompilerTest, DISABLED_TpchQ7) {  // misses FunctionExpression
@@ -319,7 +320,7 @@ TEST_F(QueryCompilerTest, TpchQ10) {
   auto query_compiler = QueryCompiler(q10, catalog_);
   EXPECT_EQ(query_compiler.GetOptimizedLqps().size(), 1);
   EXPECT_EQ(query_compiler.GetOptimizedPqps().size(), 1);
-  //  VisualizePlans(query_compiler, "TpchQ10");
+  VisualizePlans(query_compiler, "TpchQ10");
 }
 
 TEST_F(QueryCompilerTest, DISABLED_TpchQ11) {  // misses hsql::kExprSelect
@@ -343,7 +344,7 @@ TEST_F(QueryCompilerTest, TpchQ13) {
   auto query_compiler = QueryCompiler(q13, catalog_);
   EXPECT_EQ(query_compiler.GetOptimizedLqps().size(), 1);
   EXPECT_EQ(query_compiler.GetOptimizedPqps().size(), 1);
-  //  VisualizePlans(query_compiler, "TpchQ13");
+  VisualizePlans(query_compiler, "TpchQ13");
 }
 
 TEST_F(QueryCompilerTest, DISABLED_TpchQ14) {  // misses CaseExpression


### PR DESCRIPTION
The entry point for SQL compilation is the `QueryCompiler`.
For parsing, it utilizes the [Hyrise SQL Parser](https://github.com/hyrise/sql-parser), which translates SQL strings into parse trees. 

Since SQL strings may consist of multiple statements (delimited with `;`), a `QueryStatementCompiler` instance is invoked for each statement or parse tree to generate the according logical and physical plans.

**ToDos**

- [ ] Adapt code to recent master changes
- [ ] Refactor tests & add some new ones where appropriate. (During my master's thesis, I had time for rudimentary testing only)