### PR TITLE
Pipeline Preparation Rule for PQPs

### DIFF
--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -75,6 +75,12 @@ set(
 )
 
 set(
+    QUERY_COMPILER_SOURCES
+    compiler/optimizer/strategy/pqp_pipeline_preparation_rule.hpp
+    compiler/optimizer/strategy/pqp_pipeline_preparation_rule.cpp
+)
+
+set(
     SHARED_SOURCES
     aggregate_traits.hpp
     all_type_variant.hpp

--- a/src/lib/compiler/optimizer/strategy/pqp_pipeline_preparation_rule.cpp
+++ b/src/lib/compiler/optimizer/strategy/pqp_pipeline_preparation_rule.cpp
@@ -1,0 +1,85 @@
+#include "pqp_pipeline_preparation_rule.hpp"
+
+#include <set>
+#include <unordered_set>
+
+#include "compiler/physical_query_plan/exchange_operator_proxy.hpp"
+#include "compiler/physical_query_plan/pqp_utils.hpp"
+#include "compiler/plan_utils.hpp"
+
+namespace {
+using namespace skyrise;  // NOLINT(google-build-using-namespace)
+}  // namespace
+
+namespace skyrise {
+
+const std::string& PqpPipelinePreparationRule::Name() const {
+  static const std::string rule_name = "PqpAggregateSplitUpRule";
+  return rule_name;
+}
+
+void PqpPipelinePreparationRule::ApplyTo(const std::shared_ptr<AbstractOperatorProxy>& pqp_root) const {
+  Assert(pqp_root->Type() == OperatorType::kExport, "PQP root should have OperatorType::kExport.");
+  std::unordered_set<std::shared_ptr<AbstractOperatorProxy>> visited_proxies;
+  std::vector<std::shared_ptr<AbstractOperatorProxy>> pqp_leaves = PqpFindLeaves(pqp_root);
+
+  for (const auto& pqp_leaf : pqp_leaves) {
+    Assert(pqp_leaf->Type() == OperatorType::kImport, "PQP leaf should have OperatorType::kImport.");
+    if (pqp_leaf->OutputNodeCount() > 1) {
+      Fail("Currently, " + Name() + " accepts one output per ImportOperatorProxy only.");
+      // TODO(anyone): To simplify pipeline-slicing, an ImportOperatorProxy should have one output only.
+      //               Next steps: 1) Deep-copy pqp_leaf (OutputCount - 1) times.
+      //                           2) Reconnect: Outputs()->at(1..n) to new ImportOperatorProxy instance from 1)
+      //                           3) Write test & verify impl.
+    }
+
+    /**
+     * (1) Determine pipeline breakers that require data shuffling.
+     */
+    VisitPqpUpwards(pqp_leaf, [&visited_proxies](const auto& operator_proxy) {
+      // TODO(julianmenzler): C++20: Replace with .contains
+      if (visited_proxies.find(operator_proxy) != visited_proxies.end()) {
+        return PqpUpwardVisitation::kDoNotVisitOutputs;
+      }
+      visited_proxies.insert(operator_proxy);
+
+      if (!operator_proxy->IsPipelineBreaker() || operator_proxy->Type() == OperatorType::kExchange) {
+        // Skip data exchange operators because they already model data shuffling.
+        // Also, other operators, such as filters and projections, which do not require data shuffling.
+        return PqpUpwardVisitation::kVisitOutputs;
+      }
+      if (operator_proxy->InputObjectsCount() == 1) {
+        // In case of a single input object, data shuffling is unnecessary.
+        // For example: A sort operation that follows a final aggregation does not require data shuffling.
+        return PqpUpwardVisitation::kVisitOutputs;
+      }
+
+      /**
+       * (2) Model data shuffling: Insert ExchangeOperatorProxy before pipeline breaker's input(s).
+       */
+      Assert(operator_proxy->InputNodeCount() > 0,
+             "Expected " + operator_proxy->Name() + " to have at least one input.");
+      auto model_data_shuffling = [&operator_proxy](const PlanInputSide input_side) {
+        auto input_proxy = operator_proxy->Input(input_side);
+        if (input_proxy->Type() == OperatorType::kImport) {
+          return;
+        }
+        if (input_proxy->Type() == OperatorType::kExchange) {
+          return;
+        }
+
+        auto exchange_proxy = ExchangeOperatorProxy::Make();
+        PlanInsertNodeBelow<AbstractOperatorProxy>(operator_proxy, input_side, exchange_proxy);
+      };
+
+      model_data_shuffling(PlanInputSide::kLeft);
+      if (operator_proxy->InputNodeCount() == 2) {
+        model_data_shuffling(PlanInputSide::kRight);
+      }
+
+      return PqpUpwardVisitation::kVisitOutputs;
+    });
+  }
+}
+
+}  // namespace skyrise

--- a/src/lib/compiler/optimizer/strategy/pqp_pipeline_preparation_rule.hpp
+++ b/src/lib/compiler/optimizer/strategy/pqp_pipeline_preparation_rule.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "compiler/optimizer/abstract_rule.hpp"
+#include "compiler/physical_query_plan/abstract_operator_proxy.hpp"
+
+namespace skyrise {
+
+/**
+ * Prepares the given PQP for PqpPipelineSlicer:
+ *  a) Determines operators that require data shuffling and inserts ExchangeOperatorProxy objects before those.
+ *  b) Replicates ImportOperatorProxy as necessary, so that each ImportOperatorProxy has one output only.
+ *     (TODO(anyone): Not yet implemented, see comment in cpp file)
+ */
+class PqpPipelinePreparationRule : public AbstractRule {
+ public:
+  const std::string& Name() const override;
+
+  void ApplyTo(const std::shared_ptr<AbstractOperatorProxy>& pqp_root) const override;
+};
+
+}  // namespace skyrise

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -18,6 +18,8 @@ set(
     benchmark/lib/lambda/lambda_benchmark_result_test.cpp
     benchmark/lib/lambda/lambda_benchmark_runner_test.cpp
 
+    lib/compiler/optimizer/strategy/pqp_pipeline_prepartion_rule_test.cpp
+
     lib/compiler/physical_query_plan/aggregate_operator_proxy_test.cpp
     lib/compiler/physical_query_plan/alias_operator_proxy_test.cpp
     lib/compiler/physical_query_plan/exchange_operator_proxy_test.cpp

--- a/src/test/lib/compiler/optimizer/strategy/pqp_pipeline_prepartion_rule_test.cpp
+++ b/src/test/lib/compiler/optimizer/strategy/pqp_pipeline_prepartion_rule_test.cpp
@@ -1,0 +1,206 @@
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "compiler/optimizer/strategy/pqp_pipeline_preparation_rule.hpp"
+#include "compiler/physical_query_plan/aggregate_operator_proxy.hpp"
+#include "compiler/physical_query_plan/exchange_operator_proxy.hpp"
+#include "compiler/physical_query_plan/export_operator_proxy.hpp"
+#include "compiler/physical_query_plan/filter_operator_proxy.hpp"
+#include "compiler/physical_query_plan/import_operator_proxy.hpp"
+#include "compiler/physical_query_plan/sort_operator_proxy.hpp"
+#include "compiler/physical_query_plan/union_operator_proxy.hpp"
+#include "expression/expression_functional.hpp"
+#include "types.hpp"
+
+namespace skyrise {
+
+using namespace skyrise::expression_functional;  // NOLINT(google-build-using-namespace)
+
+class PqpPipelinePreparationRuleTest : public ::testing::Test {
+ public:
+  void SetUp() override {
+    rule_ = std::make_unique<PqpPipelinePreparationRule>();
+
+    const std::vector<std::string> object_keys{"partition1", "partition2", "partition3"};
+    import_proxy_a_ = ImportOperatorProxy::Make(bucket_name_, object_keys, column_ids_);
+    import_proxy_b_ = ImportOperatorProxy::Make(bucket_name_, object_keys, column_ids_);
+
+    a_a_ = PqpColumn_(ColumnId{0}, DataType::kLong, false, "a_a");
+    a_b_ = PqpColumn_(ColumnId{1}, DataType::kLong, false, "a_b");
+    b_x_ = PqpColumn_(ColumnId{0}, DataType::kLong, false, "b_x");
+    b_y_ = PqpColumn_(ColumnId{1}, DataType::kLong, false, "b_y");
+
+    SortColumnDefinition sort_definition1{ColumnId{0}, SortMode::kAscending};
+    SortColumnDefinition sort_definition2{ColumnId{1}, SortMode::kAscending};
+    sort_definitions_ = {sort_definition1, sort_definition2};
+  }
+
+ protected:
+  static inline const std::string bucket_name_ = "dummy_bucket";
+  static inline const std::vector<ColumnId> column_ids_ = {ColumnId{2}, ColumnId{4}};
+  static inline const std::string target_object_key_ = "dummy_target_object_key";
+  static inline const auto export_format_ = ExportFormat::kOrc;
+
+  std::unique_ptr<PqpPipelinePreparationRule> rule_;
+
+  std::shared_ptr<ImportOperatorProxy> import_proxy_a_;
+  std::shared_ptr<ImportOperatorProxy> import_proxy_b_;
+
+  std::shared_ptr<PqpColumnExpression> a_a_;
+  std::shared_ptr<PqpColumnExpression> a_b_;
+  std::shared_ptr<PqpColumnExpression> b_x_;
+  std::shared_ptr<PqpColumnExpression> b_y_;
+
+  std::vector<SortColumnDefinition> sort_definitions_;
+};
+
+TEST_F(PqpPipelinePreparationRuleTest, AggregateShuffle) {
+  std::vector<ColumnId> group_by_column_ids = {ColumnId(1)};
+  auto aggregates = ExpressionVector_(Sum_(a_a_));
+  // clang-format off
+  auto pqp =
+  ExportOperatorProxy::Make(bucket_name_, target_object_key_, export_format_,
+    AggregateOperatorProxy::Make(group_by_column_ids, aggregates,
+      FilterOperatorProxy::Make(GreaterThan_(a_a_, 700),
+        import_proxy_a_)));
+  // clang-format on
+
+  rule_->ApplyTo(pqp);
+
+  // PartitionOperatorProxy should be placed beneath the AggregateOperatorProxy
+  EXPECT_EQ(pqp->Type(), OperatorType::kExport);
+  EXPECT_EQ(pqp->LeftInput()->Type(), OperatorType::kAggregate);
+  ASSERT_EQ(pqp->LeftInput()->LeftInput()->Type(), OperatorType::kExchange);
+  EXPECT_EQ(pqp->LeftInput()->LeftInput()->LeftInput()->Type(), OperatorType::kFilter);
+  EXPECT_EQ(pqp->LeftInput()->LeftInput()->LeftInput()->LeftInput()->Type(), OperatorType::kImport);
+
+  auto exchange_proxy = std::dynamic_pointer_cast<ExchangeOperatorProxy>(pqp->LeftInput()->LeftInput());
+  EXPECT_EQ(exchange_proxy->GetExchangeMode(), ExchangeMode::kFullMerge);
+  EXPECT_EQ(exchange_proxy->OutputObjectsCount(), 1);
+}
+
+TEST_F(PqpPipelinePreparationRuleTest, AggregateNoShuffle) {
+  // Data shuffling is not necessary when there is only one input object.
+  std::vector<std::string> object_keys = {"single_partition"};
+
+  std::vector<ColumnId> group_by_column_ids = {ColumnId(1)};
+  auto aggregates = ExpressionVector_(Sum_(a_a_));
+  // clang-format off
+  auto pqp =
+  ExportOperatorProxy::Make(bucket_name_, target_object_key_, export_format_,
+    AggregateOperatorProxy::Make(group_by_column_ids, aggregates,
+      FilterOperatorProxy::Make(GreaterThan_(a_a_, 700),
+        ImportOperatorProxy::Make(bucket_name_, object_keys, column_ids_))));
+  // clang-format on
+
+  rule_->ApplyTo(pqp);
+
+  // PQP should not change.
+  EXPECT_EQ(pqp->Type(), OperatorType::kExport);
+  EXPECT_EQ(pqp->LeftInput()->Type(), OperatorType::kAggregate);
+  EXPECT_EQ(pqp->LeftInput()->LeftInput()->Type(), OperatorType::kFilter);
+  EXPECT_EQ(pqp->LeftInput()->LeftInput()->LeftInput()->Type(), OperatorType::kImport);
+}
+
+TEST_F(PqpPipelinePreparationRuleTest, SortShuffle) {
+  std::vector<ColumnId> group_by_column_ids = {ColumnId(1)};
+  auto aggregates = ExpressionVector_(Sum_(a_a_));
+  // clang-format off
+  auto pqp =
+  ExportOperatorProxy::Make(bucket_name_, target_object_key_, export_format_,
+    SortOperatorProxy::Make(sort_definitions_,
+      FilterOperatorProxy::Make(GreaterThan_(a_a_, 700),
+        import_proxy_a_)));
+  // clang-format on
+
+  rule_->ApplyTo(pqp);
+
+  // PartitionOperatorProxy should be placed beneath the SortOperatorProxy
+  EXPECT_EQ(pqp->Type(), OperatorType::kExport);
+  EXPECT_EQ(pqp->LeftInput()->Type(), OperatorType::kSort);
+  ASSERT_EQ(pqp->LeftInput()->LeftInput()->Type(), OperatorType::kExchange);
+  EXPECT_EQ(pqp->LeftInput()->LeftInput()->LeftInput()->Type(), OperatorType::kFilter);
+  EXPECT_EQ(pqp->LeftInput()->LeftInput()->LeftInput()->LeftInput()->Type(), OperatorType::kImport);
+
+  auto exchange_proxy = std::dynamic_pointer_cast<ExchangeOperatorProxy>(pqp->LeftInput()->LeftInput());
+  EXPECT_EQ(exchange_proxy->GetExchangeMode(), ExchangeMode::kFullMerge);
+  EXPECT_EQ(exchange_proxy->OutputObjectsCount(), 1);
+}
+
+TEST_F(PqpPipelinePreparationRuleTest, SortAggregateSingleShuffle) {
+  std::vector<ColumnId> group_by_column_ids = {ColumnId(1)};
+  auto aggregates = ExpressionVector_(Sum_(a_a_));
+  // clang-format off
+  auto pqp =
+  ExportOperatorProxy::Make(bucket_name_, target_object_key_, export_format_,
+    SortOperatorProxy::Make(sort_definitions_,
+      AggregateOperatorProxy::Make(group_by_column_ids, aggregates,
+        FilterOperatorProxy::Make(GreaterThan_(a_a_, 700),
+          import_proxy_a_))));
+  // clang-format on
+
+  rule_->ApplyTo(pqp);
+
+  // A PartitionOperatorProxy should be inserted beneath AggregateOperatorProxy only. The sort operation should receive
+  // a single data partition from the aggregation. Therefore, no further shuffling is required.
+  EXPECT_EQ(pqp->Type(), OperatorType::kExport);
+  EXPECT_EQ(pqp->LeftInput()->Type(), OperatorType::kSort);
+  ASSERT_EQ(pqp->LeftInput()->LeftInput()->Type(), OperatorType::kAggregate);
+  EXPECT_EQ(pqp->LeftInput()->LeftInput()->LeftInput()->Type(), OperatorType::kExchange);
+  EXPECT_EQ(pqp->LeftInput()->LeftInput()->LeftInput()->LeftInput()->Type(), OperatorType::kFilter);
+  EXPECT_EQ(pqp->LeftInput()->LeftInput()->LeftInput()->LeftInput()->LeftInput()->Type(), OperatorType::kImport);
+
+  auto exchange_proxy =
+      std::dynamic_pointer_cast<ExchangeOperatorProxy>(pqp->LeftInput()->LeftInput()->LeftInput());
+  EXPECT_EQ(exchange_proxy->GetExchangeMode(), ExchangeMode::kFullMerge);
+  EXPECT_EQ(exchange_proxy->OutputObjectsCount(), 1);
+}
+
+TEST_F(PqpPipelinePreparationRuleTest, UnionShuffle) {
+  // clang-format off
+  auto pqp =
+  ExportOperatorProxy::Make(bucket_name_, target_object_key_, export_format_,
+    UnionOperatorProxy::Make(SetOperationMode::kAll,
+      FilterOperatorProxy::Make(GreaterThan_(a_a_, 700),
+        import_proxy_a_),
+      FilterOperatorProxy::Make(LessThan_(a_b_, 123),
+        import_proxy_a_->DeepCopy()))); // TODO(julianmenzler): Remove DeepCopy() when the rule can do this itself
+  // clang-format on
+
+  rule_->ApplyTo(pqp);
+
+  EXPECT_EQ(pqp->Type(), OperatorType::kExport);
+  EXPECT_EQ(pqp->LeftInput()->Type(), OperatorType::kUnion);
+  EXPECT_EQ(pqp->LeftInput()->LeftInput()->Type(), OperatorType::kExchange);
+  EXPECT_EQ(pqp->LeftInput()->LeftInput()->LeftInput()->Type(), OperatorType::kFilter);
+  EXPECT_EQ(pqp->LeftInput()->LeftInput()->LeftInput()->LeftInput()->Type(), OperatorType::kImport);
+  EXPECT_EQ(pqp->LeftInput()->RightInput()->Type(), OperatorType::kExchange);
+  EXPECT_EQ(pqp->LeftInput()->RightInput()->LeftInput()->Type(), OperatorType::kFilter);
+  EXPECT_EQ(pqp->LeftInput()->RightInput()->LeftInput()->LeftInput()->Type(), OperatorType::kImport);
+}
+
+TEST_F(PqpPipelinePreparationRuleTest, UnionSingleShuffle) {
+  // If there are no more operators between the Import and the pipeline breaker, data shuffling has no effect and should
+  // be avoided.
+  // clang-format off
+  auto pqp =
+  ExportOperatorProxy::Make(bucket_name_, target_object_key_, export_format_,
+    UnionOperatorProxy::Make(SetOperationMode::kAll,
+      FilterOperatorProxy::Make(GreaterThan_(a_a_, 700),
+        import_proxy_a_),
+      import_proxy_a_->DeepCopy()));  // TODO(julianmenzler): Remove DeepCopy() when the rule can do this itself
+  // clang-format on
+
+  rule_->ApplyTo(pqp);
+
+  EXPECT_EQ(pqp->Type(), OperatorType::kExport);
+  EXPECT_EQ(pqp->LeftInput()->Type(), OperatorType::kUnion);
+  EXPECT_EQ(pqp->LeftInput()->LeftInput()->Type(), OperatorType::kExchange);
+  EXPECT_EQ(pqp->LeftInput()->LeftInput()->LeftInput()->Type(), OperatorType::kFilter);
+  EXPECT_EQ(pqp->LeftInput()->LeftInput()->LeftInput()->LeftInput()->Type(), OperatorType::kImport);
+  EXPECT_EQ(pqp->LeftInput()->RightInput()->Type(), OperatorType::kImport);
+}
+
+}  // namespace skyrise


### PR DESCRIPTION
Blocked by:

* #739

Prepares a given PQP for the upcoming `PqpPipelineSlicer` component. It determines operators that require data shuffling and inserts `ExchangeOperatorProxy` instances below.